### PR TITLE
Monitor timeseries

### DIFF
--- a/index.js
+++ b/index.js
@@ -462,7 +462,7 @@ function outputData(bot, message, metrics, responseData) {
           }
           avg = avg / points.length;
           
-          instanceMessage += metric + ': ' + newestValue.toFixed(3) + ' at ' + newestPoint.end + ' *|* ' + avg.toFixed(3) + ' average\n';
+          instanceMessage += metric + ': ' + round(newestValue, 3) + ' at ' + newestPoint.end + ' *|* ' +  round(avg, 3) + ' average\n';
         }
       } else {
         instanceMessage += metric + ': No data\n';
@@ -521,4 +521,8 @@ function getTimeseriesValue(point) {
     return parseInt(point.int64Value);
   }
   return;
+}
+
+function round(value, decimals) {
+    return Number(Math.round(value+'e'+decimals)+'e-'+decimals);
 }


### PR DESCRIPTION
This PR adds two new commands:
- `gcpbot monitor metrics <filter...>` to list all metrics. Add one or more strings to filter the results (space-separated list, results match ALL strings).
- `gcpbot monitor <metrics...>` to show the values for a set of metrics (space-separated list).

I also cleaned up the output a bit to be more scannable and have helpful emojis.
