### PR TITLE
Preparing for multiple users and wit.ai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store*
 npm-debug.log
 gcp*.json
+userdata

--- a/bot.yml
+++ b/bot.yml
@@ -3,14 +3,6 @@ description: A bot to interact with Google Cloud Platform
 avatar: images/gcp-avatar.png
 #background: resources/background.png
 config:
-  - name: PROJECT_ID
-    friendly_name: GCP Project id
-    type: text
-    global: true
-  - name: PROJECT_REGION
-    friendly_name: GCP Project Region
-    type: text
-    global: true
   - name: CLIENT_EMAIL
     friendly_name:  Client Email
     info: The client_email from your gcp authn json file

--- a/index.js
+++ b/index.js
@@ -91,10 +91,8 @@ controller.hears(['gcpbot m(onitor)? p(ack)?(.*)?'], ['message_received','ambien
   var metricString = (message.match[3] || '').trim();
   
   // First see if there's a named package
-  if (Metrics.packages[metricString]) {
-    var metrics = Metrics.packages[metricString].metrics;
-    gcpClient.monitorMetricList(bot, message, metrics);
-  } else {
+  var result = gcpClient.monitorMetricPack(bot, message, metricString);
+  if (!result) {
     var packages = '`' + Object.keys(Metrics.packages).join('`, `') + '`';
     bot.reply(message, 'Metric pack name is required. Try one of: ' + Metrics.packages);
   }

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ controller.hears(['gcpbot d(eploy)? detail (.*)'], ['message_received','ambient'
   
   getUserData(message.user).then(function(userData) {
     gcpClient.showDeployDetail(userData, bot, message, depId);
-  });
+  }, userDataErrorHandler(bot, message));
 });
 
 controller.hears(['gcpbot d(eploy)? summary (.*)'], ['message_received','ambient'], function (bot, message) {
@@ -63,16 +63,15 @@ controller.hears(['gcpbot d(eploy)? summary (.*)'], ['message_received','ambient
   var email = user.substring( user.indexOf(':') + 1, user.indexOf('|'));
   console.log(email);
 
-
   getUserData(message.user).then(function(userData) {
     gcpClient.showDeploySummary(userData, bot, message, email);
-  });
+  }, userDataErrorHandler(bot, message));
 });
 
 controller.hears(['gcpbot deploy list'], ['message_received','ambient'], function (bot, message) {
   getUserData(message.user).then(function(userData) {
     gcpClient.showDeployList(userData, bot, message);
-  });
+  }, userDataErrorHandler(bot, message));
 });
 
 // DEPLOYMENT of a file from github
@@ -82,7 +81,7 @@ controller.hears(['gcpbot d(eploy)? new (.*) (.*)'], ['message_received','ambien
   
   getUserData(message.user).then(function(userData) {
     gcpClient.newDeploy(userData, bot, message, repo, depFile);
-  });
+  }, userDataErrorHandler(bot, message));
 });
 
 controller.hears('gcpbot h(elp)?', ['message_received', 'ambient'], function (bot, message) {
@@ -106,7 +105,7 @@ controller.hears(['gcpbot m(onitor)? m(etrics)?(.*)?'], ['message_received','amb
   
   getUserData(message.user).then(function(userData) {
     gcpClient.listMetrics(userData, bot, message, parsedMetrics);
-  });
+  }, userDataErrorHandler(bot, message));
 });
 
 controller.hears(['gcpbot m(onitor)? p(ack)?(.*)?'], ['message_received','ambient'], function (bot, message) {
@@ -116,7 +115,7 @@ controller.hears(['gcpbot m(onitor)? p(ack)?(.*)?'], ['message_received','ambien
   if(Metrics.packages[metricString]) {
     getUserData(message.user).then(function(userData) {
       gcpClient.monitorMetricPack(userData, bot, message, metricString);
-    });
+    }, userDataErrorHandler(bot, message));
   } else {
     var packages = '`' + Object.keys(Metrics.packages).join('`, `') + '`';
     bot.reply(message, 'Metric pack name is required. Try one of: ' + Metrics.packages);
@@ -129,7 +128,7 @@ controller.hears(['gcpbot m(onitor)?(.*)?'], ['message_received','ambient'], fun
   if (metrics) {
     getUserData(message.user).then(function(userData) {
       gcpClient.monitorMetricList(userData, bot, message, metrics);
-    });
+    }, userDataErrorHandler(bot, message));
   } else {
     bot.reply(message, "Metrics are required.");
   }
@@ -149,6 +148,12 @@ function parseMetricsFromMessage(metricString) {
       return metrics;
   }
   return null;
+}
+
+function userDataErrorHandler(bot, message) {
+  return function(err) {
+    bot.reply(message, 'You need to tell me what project to use first. Use `gcpbot setup <projectId> <region>` to select a project and region to manage.');
+  };
 }
 
 function getUserData(user) {

--- a/index.js
+++ b/index.js
@@ -4,37 +4,20 @@ var yaml = require('yamljs');
 var Metrics = require('./lib/metrics');
 var GCPClient = require('./lib/gcpclient');
 
-// Expect a SLACK_TOKEN environment variable
-var slackToken = process.env.SLACK_TOKEN;
-if (!slackToken) {
-  console.error('SLACK_TOKEN is required!');
-  process.exit(1);
+function requireEnvVariable(name) {
+  var value = process.env[name];
+  if(!value) {
+    throw new Error(name + 'is required!');
+  }
+  return value;
 }
 
-// Expect a PROJECT_ID environment variable
-var projectId = process.env.PROJECT_ID;
-if (!projectId) {
-  console.error('PROJECT_ID is required!');
-  process.exit(1);
-}
-
-// Expect a PROJECT_REGION environment variable
-var region = process.env.PROJECT_REGION;
-if (!region) {
-  console.error('PROJECT_REGION is required!');
-  process.exit(1);
-}
-
-var private_key = process.env.PRIVATE_KEY;
-if (!private_key) {
-  console.error('PRIVATE_KEY is required!');
-  process.exit(1);
-}
-var client_email = process.env.CLIENT_EMAIL;
-if (!client_email) {
-  console.error('CLIENT_EMAIL is required!');
-  process.exit(1);
-}
+// Expect a bunch of environment variables
+var slackToken = requireEnvVariable('SLACK_TOKEN');
+var projectId = requireEnvVariable('PROJECT_ID');
+var region = requireEnvVariable('PROJECT_REGION');
+var private_key = requireEnvVariable('PRIVATE_KEY');
+var client_email = requireEnvVariable('CLIENT_EMAIL');
 
 var jwtClient = new google.auth.JWT(client_email, null, private_key,
   [

--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -8,8 +8,9 @@ var Metrics = require('./metrics');
 var GoogleChart = require('./googlechart');
 var Utils = require('./utils');
 
-function GCPClient(jwtClient) {
+function GCPClient(jwtClient, replier) {
   this.jwtClient = jwtClient;
+  this.replier = replier;
 }
 
 /**
@@ -33,15 +34,13 @@ GCPClient.prototype.authorize = function() {
  * Shows the detail for a specific deployment, including resources.
  * 
  * @param {object} userData - an object containing the projectId and region to use
- * @param {*} bot - the botkit bot to send messages with
- * @param {*} message - the slack message to reply to
  * @param {string} deployId - the id of the deployment to show detail for
  */
-GCPClient.prototype.showDeployDetail = function(userData, bot, message, deployId) {
+GCPClient.prototype.showDeployDetail = function(userData, deployId) {
   var client = this;
-  this.authorize().then(function(tokens) {
-    bot.reply(message, "Deployment detail for deployment " + deployId);
-    return checkDeploy(userData, client, bot, message, deployId);
+  return this.authorize().then(function(tokens) {
+    client.replier("Deployment detail for deployment " + deployId);
+    return checkDeploy(userData, client, deployId);
   });
 };
 
@@ -49,14 +48,14 @@ GCPClient.prototype.showDeployDetail = function(userData, bot, message, deployId
  * Shows a list of all deployments in the project
  * 
  * @param {object} userData - an object containing the projectId and region to use
- * @param {*} bot - the botkit bot to send messages with
- * @param {*} message - the slack message to reply to
  */
-GCPClient.prototype.showDeployList = function(userData, bot, message) {
+GCPClient.prototype.showDeployList = function(userData) {
   var client = this;
   this.authorize().then(function(result) {
-    bot.reply(message, "Deployment list: ");
-    return listDeployments(userData, client, bot, message);
+    client.replier("Deployment list: ");
+    return listDeployments(userData, client);
+  }, function(err) {
+    client.replier("🚫 There was an error listing deployments.");
   });
 };
 
@@ -64,16 +63,16 @@ GCPClient.prototype.showDeployList = function(userData, bot, message) {
  * Shows a summary of the deploys associated with a certain email address
  * 
  * @param {object} userData - an object containing the projectId and region to use
- * @param {*} bot - the botkit bot to send messages with
- * @param {*} message - the slack message to reply to
  * @param {string} email - the email address to search by
  */
-GCPClient.prototype.showDeploySummary = function(userData, bot, message, email) {
+GCPClient.prototype.showDeploySummary = function(userData, email) {
   var client = this;
   this.authorize().then(function(tokens) {
-    bot.reply(message, "Deployment summary for " + email);
+    client.replier("Deployment summary for " + email);
     var filterStr = 'operation.user eq ' + email;
-    return listDeployments(userData, client, bot, message, filterStr);
+    return listDeployments(userData, client, filterStr);
+  }, function(err) {
+    client.replier("🚫 There was an error listing deployments.");
   });
 };
 
@@ -81,12 +80,10 @@ GCPClient.prototype.showDeploySummary = function(userData, bot, message, email) 
  * Creates a new deploy from a specified yaml file in a github repo.
  * 
  * @param {object} userData - an object containing the projectId and region to use
- * @param {*} bot - the botkit bot to send messages with
- * @param {*} message - the slack message to reply to
  * @param {string} repo - the github repo to look in
  * @param {string} depFile - the name of the config file (without extension)
  */
-GCPClient.prototype.newDeploy = function(userData, bot, message, repo, depFile) {
+GCPClient.prototype.newDeploy = function(userData, repo, depFile) {
   var client = this;
   var yamlName = depFile + ".yaml";
   var ghPref = 'https://github.com/';
@@ -96,15 +93,15 @@ GCPClient.prototype.newDeploy = function(userData, bot, message, repo, depFile) 
   return fetchConfiguration(baseURL, yamlName).then(function(result) {
     var configString = result.body;
     if (!configString) {
-      bot.reply(message, "yaml file not found: " + url.resolve(baseURL, yamlName));
+      client.replier("yaml file not found: " + url.resolve(baseURL, yamlName));
       return;
     }
     
     var authorization = client.authorize();
-    authorization.then(insertDeployment(client, userData, bot, message, depFile, configString, result.imports));
+    authorization.then(insertDeployment(client, userData, depFile, configString, result.imports));
     authorization.catch(function(errors) {
       for(i = 0; i < errors.length; i++) {
-        bot.reply(message, '🚫 ' + errors[i]);
+        client.replier('🚫 ' + errors[i]);
       }
     });
     return authorization;
@@ -116,11 +113,9 @@ GCPClient.prototype.newDeploy = function(userData, bot, message, repo, depFile) 
  * any metric that contains ALL the provided strings. Metrics will be truncated at 50.
  * 
  * @param {object} userData - an object containing the projectId and region to use
- * @param {*} bot - the botkit bot to send messages with
- * @param {*} message - the slack message to reply to
  * @param {string[]} metricFilters - an array of Strings that filters the metrics to only ones that contain ALL of the Strings
  */
-GCPClient.prototype.listMetrics = function(userData, bot, message, metricFilters) {
+GCPClient.prototype.listMetrics = function(userData, metricFilters) {
   var client = this;
   var query = '';
   if (metricFilters) {
@@ -134,7 +129,8 @@ GCPClient.prototype.listMetrics = function(userData, bot, message, metricFilters
       filter: query },
       function(err, resp) {
         if(err) {
-          console.log(err);
+          console.log('monitoring.projects.metricDescriptors', err);
+          reject(err);
           return;
         }
 
@@ -146,8 +142,7 @@ GCPClient.prototype.listMetrics = function(userData, bot, message, metricFilters
         for(i = 0; i < limit; i++) {
           responseMessage += "\n `" + metrics[i].type + "` - " + metrics[i].description;
         }
-        bot.reply(message, responseMessage);
-
+        client.replier(responseMessage);
       }
     );
   });
@@ -157,15 +152,13 @@ GCPClient.prototype.listMetrics = function(userData, bot, message, metricFilters
  * Reply with the results of monitoring a list of metrics.
  * 
  * @param {object} userData - an object containing the projectId and region to use
- * @param {slackbot} bot - the botkit bot to send messages with
- * @param {message} message - the slack message to reply to
  * @param {string[]} metrics - a list of GCP metrics that should be monitored. e.g. "compute.googleapis.com/instance/cpu/utilization"
  * @param {string} instance - the instance to filter to
  */
-GCPClient.prototype.monitorMetricList = function(userData, bot, message, metrics, instance) {
+GCPClient.prototype.monitorMetricList = function(userData, metrics, instance) {
   var client = this;
-  this.authorize().then(function(tokens) {
-    monitorMetrics(userData, client, bot, message, metrics, instance);
+  return this.authorize().then(function(tokens) {
+    return monitorMetrics(userData, client, metrics, instance);
   });
 };
 
@@ -173,18 +166,14 @@ GCPClient.prototype.monitorMetricList = function(userData, bot, message, metrics
  * Reply with the results of monitoring a list of metrics from a predefined pack.
  * 
  * @param {object} userData - an object containing the projectId and region to use
- * @param {slackbot} bot - the botkit bot to send messages with
- * @param {message} message - the slack message to reply to
  * @param {string} packName - the name of a predefined list of metrics e.g. "cpu", "simple"
- * @returns {boolean} true if the pack exists, false otherwise 
  */
-GCPClient.prototype.monitorMetricPack = function(userData, bot, message, packName, instance) {
+GCPClient.prototype.monitorMetricPack = function(userData, packName, instance) {
   if (Metrics.packages[packName]) {
     var metrics = Metrics.packages[packName].metrics;
-    this.monitorMetricList(userData, bot, message, metrics, instance);
-    return true;
+    return this.monitorMetricList(userData, metrics, instance);
   } else {
-    return false;
+    return new Promise.resolve([]);
   }
 };
 
@@ -254,7 +243,7 @@ function fetchNextFile(files, baseURL, isConfig, callback) {
   });
 }
 
-function sendDeployDetailReplies(bot, message, deploy, includeProgressLink) {
+function sendDeployDetailReplies(client, deploy, includeProgressLink) {
   var statusIcon = emojiForStatus(deploy.operation.status);
   var replyMessage = statusIcon + " Deploy *" +
     deploy.name + "* Status: " + deploy.operation.status +
@@ -267,21 +256,19 @@ function sendDeployDetailReplies(bot, message, deploy, includeProgressLink) {
     replyMessage += "\n" + deploy.operation.progress + "% complete. To view progress, navigate to " +
       " https://console.cloud.google.com/deployments?authuser=1&project=" + process.env.PROJECT_ID;
   }
-  bot.reply(message, replyMessage);
+  client.replier(replyMessage);
   
   // print out the errors if the deployed is complete and had errors
-  if( deploy.operation.status == "DONE" || deploy.operation.status == "COMPLETE" ) {
-    if ( deploy.operation.error ) {
-      var errors = deploy.operation.error.errors;
-      for ( var errorNum in errors ) {
-        var error = errors[errorNum];
-        bot.reply(message, "🚫 *Error*: " + error.code + " *location*: " + error.location + " *message*: " + error.message);
-      }
+  if ( deploy.operation.error && (deploy.operation.status == "DONE" || deploy.operation.status == "COMPLETE") ) {
+    var errors = deploy.operation.error.errors;
+    for ( var errorNum in errors ) {
+      var error = errors[errorNum];
+      client.replier("🚫 *Error*: " + error.code + " *location*: " + error.location + " *message*: " + error.message);
     }
   }
 }
 
-function listResources(userData, client, bot, message, depName) {
+function listResources(userData, client, depName) {
   return new Promise(function (fulfill, reject) {
     var params = {
       auth: client.jwtClient,
@@ -290,41 +277,39 @@ function listResources(userData, client, bot, message, depName) {
     };
     manager.resources.list(params, function(err, resp) {
       if(err) {
-        console.log(err);
+        console.log('manager.resources.list', err);
         reject(err);
         return;
       }
       if(!resp.resources) {
-        bot.reply(message, "No resourses.");
-        fulfill();
-        return;
-      }
+        client.replier("No resourses.");
+      } else {
+        //for each resource, check status of machine - if there's an error - check logs
+        resList = resp.resources;
+        client.replier("Deploy *" + depName + "* resource summary:");
 
-      //for each resource, check status of machine - if there's an error - check logs
-      resList = resp.resources;
-      bot.reply(message, "Deploy *" + depName + "* resource summary:");
+        for ( var i = 0; i < resList.length; i++ ) {
+          var resName = resList[i].name;
+          var resType = resList[i].type;
 
-      for ( var i = 0; i < resList.length; i++ ) {
-        var resName = resList[i].name;
-        var resType = resList[i].type;
-
-        //get the yaml for the properties, and pull out some interesting info
-        var propObj = {};
-        if (resList[i].finalProperties) {
-          propObj = yaml.parse(resList[i].finalProperties);
+          //get the yaml for the properties, and pull out some interesting info
+          var propObj = {};
+          if (resList[i].finalProperties) {
+            propObj = yaml.parse(resList[i].finalProperties);
+          }
+          client.replier("📋 Resource #" + i + ":");
+          client.replier("*Name:* " + resName +
+            "\n*Type:* " + resType +
+            "\n*Machine Class:* " + propObj.machineType +
+            "\n*Zone:* " + propObj.zone );
         }
-        bot.reply(message, "📋 Resource #" + i + ":");
-        bot.reply(message, "*Name:* " + resName +
-          "\n*Type:* " + resType +
-          "\n*Machine Class:* " + propObj.machineType +
-          "\n*Zone:* " + propObj.zone );
       }
       fulfill();
     });
   });
 }
 
-function checkDeploy(userData, client, bot, message, depName) {
+function checkDeploy(userData, client, depName) {
   var status = "";
   var filterStr = 'name eq ' + depName;
 
@@ -342,21 +327,21 @@ function checkDeploy(userData, client, bot, message, depName) {
       }
 
       if(!resp.deployments) {
-        bot.reply(message, "No deployment found");
+        client.replier("No deployment found");
         fulfill();
         return;
       }
       var currDeploy = resp.deployments[0];
-      sendDeployDetailReplies(bot, message, resp.deployments[0]);
+      sendDeployDetailReplies(client, resp.deployments[0], false);
 
       if(currDeploy.operation.status != "DONE" && currDeploy.operation.status != "COMPLETE") {
         // Fulfill with another promise to check it again in 2 seconds.
         setTimeout(function() {
-          fulfill(checkDeploy(userData, client, bot, message, depName));
+          fulfill(checkDeploy(userData, client, depName));
         }, 2000);
       } else {
         //now get the resources based on the dep name
-        fulfill(listResources(userData, client, bot, message, depName));
+        fulfill(listResources(userData, client, depName));
       }
     });
   });
@@ -377,7 +362,7 @@ function invertMetricsData(responseData) {
   return instanceData;
 }
 
-function outputMetricsData(bot, message, metrics, responseData) {  
+function outputMetricsData(client, metrics, responseData) {
   // Swap around the data to be per instance instead of per metric
   var instanceData = invertMetricsData(responseData);
   
@@ -423,15 +408,14 @@ function outputMetricsData(bot, message, metrics, responseData) {
       attachments.push(attachment);
     }
     
-    bot.reply(message, {
+    client.replier({
       'text': instanceMessage,
-      'username': bot.identity.name, // Required to add image attachments
       'attachments': attachments
     }); 
   }
   
   if (!hasData) {
-    bot.reply(message, 'No monitor data returned.');
+    client.replier('No monitor data returned.');
   }
 }
 
@@ -445,30 +429,23 @@ function monitorSeries(userData, client, metric, instance, callback) {
     filter += ' AND metric.label.instance_name = "' + instance + '"';
   }
   console.log('filter:', filter, 'instance:', instance);
-  monitoring.projects.timeSeries.list({
-      auth: client.jwtClient,
-      name: 'projects/' + userData.projectId,
-      filter: filter,
-      'interval.startTime': startDate.toJSON(),
-      'interval.endTime': endDate.toJSON(),
-      'aggregation.perSeriesAligner': Metrics.alignments[metric] || 'ALIGN_MAX',
-      'aggregation.alignmentPeriod': Utils.calculateIntervalLength(startDate, endDate, 350) + 's'
-    },
-    function( err, resp ) {
-      if (err) {
-        console.log(err);
-        callback(metric, null, err);
-        return;
-      }
-      
-      if (resp.timeSeries) {
-        callback(metric, resp.timeSeries);
-      } else {
-        callback(metric);
-        console.log("timeSeries response:", resp);
-      }
+  var params = {
+    auth: client.jwtClient,
+    name: 'projects/' + userData.projectId,
+    filter: filter,
+    'interval.startTime': startDate.toJSON(),
+    'interval.endTime': endDate.toJSON(),
+    'aggregation.perSeriesAligner': Metrics.alignments[metric] || 'ALIGN_MAX',
+    'aggregation.alignmentPeriod': Utils.calculateIntervalLength(startDate, endDate, 350) + 's'
+  };
+  monitoring.projects.timeSeries.list(params, function( err, resp ) {
+    if (err) {
+      console.log('monitoring.projects.timeSeries.list', err);
+      callback(metric, null, err);
+      return;
     }
-  );
+    callback(metric, resp.timeSeries);
+  });
 }
 
 function getTimeSeriesValue(point) {
@@ -480,7 +457,7 @@ function getTimeSeriesValue(point) {
   return;
 }
 
-function listDeployments(userData, client, bot, message, filterStr) {
+function listDeployments(userData, client, filterStr) {
   var params = {
     auth: client.jwtClient,
     project: userData.projectId,
@@ -492,18 +469,16 @@ function listDeployments(userData, client, bot, message, filterStr) {
   return new Promise(function(fulfill, reject) {
     manager.deployments.list(params, function(err, resp) {
       if(err) {
-        console.log(err);
-        bot.reply(message, "🚫 There was an error listing deployments.");
         reject(err);
         return;
       }
 
       if(!resp.deployments) {
-        bot.reply(message, "No deployments to report on");
-        fulfill();
+        client.replier("No deployments to report on.");
+        fulfil();
         return;
       }
-
+      
       var deployTotalCount = resp.deployments.length;
       var activeDeploys = [];
       var deadDeploys = [];
@@ -516,45 +491,46 @@ function listDeployments(userData, client, bot, message, filterStr) {
         }
       }
 
-      bot.reply(message, "Deployments *Total Count*: " + deployTotalCount + " *Active*: " + activeDeploys.length);
-
+      client.replier("Deployments *Total Count*: " + deployTotalCount + " *Active*: " + activeDeploys.length);
       for(i = 0; i < activeDeploys.length; i++) {
-        sendDeployDetailReplies(bot, message, activeDeploys[i], true);
+        sendDeployDetailReplies(client, activeDeploys[i], true);
       }
-
       for(i = 0; i < deadDeploys.length; i++) {
-        sendDeployDetailReplies(bot, message, deadDeploys[i], false);
+        sendDeployDetailReplies(client, deadDeploys[i], false);
       }
       fulfill();
     });
   });
 }
 
-function monitorMetrics(userData, client, bot, message, metrics, instance) {
-  var responseData = {};
-  var metricsComplete = 0;
-  
-  var monitorCallback = function(metric, timeSeries, error) {
-    if (error) {
-      bot.reply(message, error.message);
+function monitorMetrics(userData, client, metrics, instance) {
+  return new Promise(function(fulfill, reject) {
+    var responseData = {};
+    var metricsComplete = 0;
+    
+    var monitorCallback = function(metric, timeSeries, error) {
+      if (error) {
+        client.replier(error.message);
+      }
+      if (timeSeries) {
+        responseData[metric] = timeSeries;
+      }
+      metricsComplete++;
+      if (metricsComplete == metrics.length) {
+        outputMetricsData(client, metrics, responseData);
+        fulfill();
+      }
+    };
+    
+    for (var i in metrics) {
+      var metric = metrics[i];
+      responseData[metric] = [];
+      monitorSeries(userData, client, metric, instance, monitorCallback);
     }
-    if (timeSeries) {
-      responseData[metric] = timeSeries;
-    }
-    metricsComplete++;
-    if (metricsComplete == metrics.length) {
-      outputMetricsData(bot, message, metrics, responseData);
-    }
-  };
-  
-  for (var i in metrics) {
-    var metric = metrics[i];
-    responseData[metric] = [];
-    monitorSeries(userData, client, metric, instance, monitorCallback);
-  }
+  });
 }
 
-function insertDeployment(client, userData, bot, message, depFile, configString, imports) {
+function insertDeployment(client, userData, depFile, configString, imports) {
   return new Promise(function(fulfill, reject) {
     var depName = depFile + Math.floor(new Date() / 1000);
     // Now insert the dependency
@@ -575,7 +551,7 @@ function insertDeployment(client, userData, bot, message, depFile, configString,
       if(err) {
         reject(err);
       } else {
-        fulfill(checkDeploy(userData, client, bot, message, depName));
+        fulfill(checkDeploy(userData, client, depName));
       }
     });
   });

--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -8,20 +8,19 @@ var Metrics = require('./metrics');
 var GoogleChart = require('./googlechart');
 var Utils = require('./utils');
 
-function GCPClient(jwtClient, projectId, region) {
+function GCPClient(jwtClient) {
   this.jwtClient = jwtClient;
-  this.projectId = projectId;
-  this.region = region;
 }
 
 /**
  * Shows the detail for a specific deployment, including resources.
  * 
+ * @param {object} userData - an object containing the projectId and region to use
  * @param {*} bot - the botkit bot to send messages with
  * @param {*} message - the slack message to reply to
  * @param {string} deployId - the id of the deployment to show detail for
  */
-GCPClient.prototype.showDeployDetail = function(bot, message, deployId) {
+GCPClient.prototype.showDeployDetail = function(userData, bot, message, deployId) {
   var client = this;
   this.jwtClient.authorize(function(err, tokens) {
     if (err) {
@@ -30,17 +29,18 @@ GCPClient.prototype.showDeployDetail = function(bot, message, deployId) {
     }
 
     bot.reply(message, "Deployment detail for deployment " + deployId);
-    checkDeploy(client, bot, message, deployId);
+    checkDeploy(userData, client, bot, message, deployId);
   });
 };
 
 /**
  * Shows a list of all deployments in the project
  * 
+ * @param {object} userData - an object containing the projectId and region to use
  * @param {*} bot - the botkit bot to send messages with
  * @param {*} message - the slack message to reply to
  */
-GCPClient.prototype.showDeployList = function(bot, message) {
+GCPClient.prototype.showDeployList = function(userData, bot, message) {
   var client = this;
   this.jwtClient.authorize(function(err, tokens) {
     if (err) {
@@ -49,18 +49,19 @@ GCPClient.prototype.showDeployList = function(bot, message) {
     }
 
     bot.reply(message, "Deployment list: ");
-    listDeployments(client, bot, message);
+    listDeployments(userData, client, bot, message);
   });
 };
 
 /**
  * Shows a summary of the deploys associated with a certain email address
  * 
+ * @param {object} userData - an object containing the projectId and region to use
  * @param {*} bot - the botkit bot to send messages with
  * @param {*} message - the slack message to reply to
  * @param {string} email - the email address to search by
  */
-GCPClient.prototype.showDeploySummary = function(bot, message, email) {
+GCPClient.prototype.showDeploySummary = function(userData, bot, message, email) {
   var client = this;
   this.jwtClient.authorize(function(err, tokens) {
     if (err) {
@@ -70,19 +71,20 @@ GCPClient.prototype.showDeploySummary = function(bot, message, email) {
 
     bot.reply(message, "Deployment summary for " + email);
     var filterStr = 'operation.user eq ' + email;
-    listDeployments(client, bot, message, filterStr);
+    listDeployments(userData, client, bot, message, filterStr);
   });
 };
 
 /**
  * Creates a new deploy from a specified yaml file in a github repo.
  * 
+ * @param {object} userData - an object containing the projectId and region to use
  * @param {*} bot - the botkit bot to send messages with
  * @param {*} message - the slack message to reply to
  * @param {string} repo - the github repo to look in
  * @param {string} depFile - the name of the config file (without extension)
  */
-GCPClient.prototype.newDeploy = function(bot, message, repo, depFile) {
+GCPClient.prototype.newDeploy = function(userData, bot, message, repo, depFile) {
   var client = this;
   var yamlName = depFile + ".yaml";
   var ghPref = 'https://github.com/';
@@ -113,8 +115,8 @@ GCPClient.prototype.newDeploy = function(bot, message, repo, depFile) {
       var depName = depFile + Math.floor(new Date() / 1000);
       // Now insert the dependency
       manager.deployments.insert({
-          auth: client.jwtClient,
-          project: client.projectId,
+          auth: this.jwtClient,
+          project: userData.projectId,
           resource: {
             name: depName,
             target: {
@@ -130,7 +132,7 @@ GCPClient.prototype.newDeploy = function(bot, message, repo, depFile) {
             console.log(err);
             return;
           }
-          checkDeploy(client, bot, message, depName);
+          checkDeploy(userData, client, bot, message, depName);
         });
       });
     });
@@ -140,11 +142,12 @@ GCPClient.prototype.newDeploy = function(bot, message, repo, depFile) {
  * Show a list of metrics with an optional array of filter strings. The filter works by matching
  * any metric that contains ALL the provided strings. Metrics will be truncated at 50.
  * 
+ * @param {object} userData - an object containing the projectId and region to use
  * @param {*} bot - the botkit bot to send messages with
  * @param {*} message - the slack message to reply to
- * @param {...string} metricFilters - an array of Strings that filters the metrics to only ones that contain ALL of the Strings
+ * @param {string[]} metricFilters - an array of Strings that filters the metrics to only ones that contain ALL of the Strings
  */
-GCPClient.prototype.listMetrics = function(bot, message, metricFilters) {
+GCPClient.prototype.listMetrics = function(userData, bot, message, metricFilters) {
   var client = this;
   var query = '';
   if (metricFilters) {
@@ -157,10 +160,9 @@ GCPClient.prototype.listMetrics = function(bot, message, metricFilters) {
       return;
     }
     
-    
     monitoring.projects.metricDescriptors.list({
       auth: client.jwtClient,
-      name: 'projects/' + client.projectId,
+      name: 'projects/' + userData.projectId,
       filter: query },
       function(err, resp) {
 
@@ -186,33 +188,37 @@ GCPClient.prototype.listMetrics = function(bot, message, metricFilters) {
 
 /**
  * Reply with the results of monitoring a list of metrics.
+ * 
+ * @param {object} userData - an object containing the projectId and region to use
  * @param {slackbot} bot - the botkit bot to send messages with
  * @param {message} message - the slack message to reply to
- * @param {...string} metrics - a list of GCP metrics that should be monitored. e.g. "compute.googleapis.com/instance/cpu/utilization"
+ * @param {string[]} metrics - a list of GCP metrics that should be monitored. e.g. "compute.googleapis.com/instance/cpu/utilization"
  * @param {string} instance - the instance to filter to
  */
-GCPClient.prototype.monitorMetricList = function(bot, message, metrics, instance) {
+GCPClient.prototype.monitorMetricList = function(userData, bot, message, metrics, instance) {
   var client = this;
   this.jwtClient.authorize(function(err, tokens) {
     if (err) {
       console.log(err);
       return;
     }
-    monitorMetrics(client, bot, message, metrics, instance);
+    monitorMetrics(userData, client, bot, message, metrics, instance);
   });
 };
 
 /**
  * Reply with the results of monitoring a list of metrics from a predefined pack.
+ * 
+ * @param {object} userData - an object containing the projectId and region to use
  * @param {slackbot} bot - the botkit bot to send messages with
  * @param {message} message - the slack message to reply to
  * @param {string} packName - the name of a predefined list of metrics e.g. "cpu", "simple"
  * @returns {boolean} true if the pack exists, false otherwise 
  */
-GCPClient.prototype.monitorMetricPack = function(bot, message, packName, instance) {
+GCPClient.prototype.monitorMetricPack = function(userData, bot, message, packName, instance) {
   if (Metrics.packages[packName]) {
     var metrics = Metrics.packages[packName].metrics;
-    this.monitorMetricList(bot, message, metrics, instance);
+    this.monitorMetricList(userData, bot, message, metrics, instance);
     return true;
   } else {
     return false;
@@ -304,14 +310,14 @@ function sendDeployDetailReplies(bot, message, deploy, includeProgressLink) {
   }
 }
 
-function checkDeploy(client, bot, message, depName) {
+function checkDeploy(userData, client, bot, message, depName) {
   var status = "";
   var filterStr = 'name eq ' + depName;
 
   return manager.deployments.list({
     auth: client.jwtClient,
-    project: client.projectId,
-    region: client.region,
+    project: userData.projectId,
+    region: userData.region,
     filter: filterStr },
     function(err, resp) {
       if( err) {
@@ -328,14 +334,14 @@ function checkDeploy(client, bot, message, depName) {
 
       if( currDeploy.operation.status != "DONE" && currDeploy.operation.status != "COMPLETE" ) {
         setTimeout(function() {
-          checkDeploy(client, bot, message, depName);
+          checkDeploy(userData, client, bot, message, depName);
         }, 2000);
       }
       else {
         //now get the resources based on the dep name
         manager.resources.list({
             auth: client.jwtClient,
-            project: client.projectId,
+            project: userData.projectId,
             deployment: depName
           },
           function(err, resp) {
@@ -447,7 +453,7 @@ function outputMetricsData(bot, message, metrics, responseData) {
   }
 }
 
-function monitorSeries(client, metric, instance, callback) {
+function monitorSeries(userData, client, metric, instance, callback) {
   var startDate = new Date();
   var endDate = new Date();
   startDate.setDate(startDate.getDate() - 1);
@@ -459,7 +465,7 @@ function monitorSeries(client, metric, instance, callback) {
   console.log('filter:', filter, 'instance:', instance);
   monitoring.projects.timeSeries.list({
       auth: client.jwtClient,
-      name: 'projects/' + client.projectId,
+      name: 'projects/' + userData.projectId,
       filter: filter,
       'interval.startTime': startDate.toJSON(),
       'interval.endTime': endDate.toJSON(),
@@ -492,11 +498,11 @@ function getTimeSeriesValue(point) {
   return;
 }
 
-function listDeployments(client, bot, message, filterStr) {
+function listDeployments(userData, client, bot, message, filterStr) {
   var params = {
     auth: client.jwtClient,
-    project: client.projectId,
-    region: client.region };
+    project: userData.projectId,
+    region: userData.region };
   if (filterStr) {
     params.filter = filterStr;
   }
@@ -538,7 +544,7 @@ function listDeployments(client, bot, message, filterStr) {
     });
 }
 
-function monitorMetrics(client, bot, message, metrics, instance) {
+function monitorMetrics(userData, client, bot, message, metrics, instance) {
   var responseData = {};
   var metricsComplete = 0;
   
@@ -558,7 +564,7 @@ function monitorMetrics(client, bot, message, metrics, instance) {
   for (var i in metrics) {
     var metric = metrics[i];
     responseData[metric] = [];
-    monitorSeries(client, metric, instance, monitorCallback);
+    monitorSeries(userData, client, metric, instance, monitorCallback);
   }
 }
 

--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -189,16 +189,34 @@ GCPClient.prototype.listMetrics = function(bot, message, metricFilters) {
  * @param {slackbot} bot - the botkit bot to send messages with
  * @param {message} message - the slack message to reply to
  * @param {...string} metrics - a list of GCP metrics that should be monitored. e.g. "compute.googleapis.com/instance/cpu/utilization"
+ * @param {string} instance - the instance to filter to
  */
-GCPClient.prototype.monitorMetricList = function(bot, message, metrics) {
+GCPClient.prototype.monitorMetricList = function(bot, message, metrics, instance) {
   var client = this;
   this.jwtClient.authorize(function(err, tokens) {
     if (err) {
       console.log(err);
       return;
     }
-    monitorMetrics(client, bot, message, metrics);
+    monitorMetrics(client, bot, message, metrics, instance);
   });
+};
+
+/**
+ * Reply with the results of monitoring a list of metrics from a predefined pack.
+ * @param {slackbot} bot - the botkit bot to send messages with
+ * @param {message} message - the slack message to reply to
+ * @param {string} packName - the name of a predefined list of metrics e.g. "cpu", "simple"
+ * @returns {boolean} true if the pack exists, false otherwise 
+ */
+GCPClient.prototype.monitorMetricPack = function(bot, message, packName, instance) {
+  if (Metrics.packages[packName]) {
+    var metrics = Metrics.packages[packName].metrics;
+    this.monitorMetricList(bot, message, metrics, instance);
+    return true;
+  } else {
+    return false;
+  }
 };
 
 function emojiForStatus(status) {
@@ -429,15 +447,20 @@ function outputMetricsData(bot, message, metrics, responseData) {
   }
 }
 
-function monitorSeries(client, metric, callback) {
+function monitorSeries(client, metric, instance, callback) {
   var startDate = new Date();
   var endDate = new Date();
   startDate.setDate(startDate.getDate() - 1);
   
+  var filter = 'metric.type = "' + metric + '"';
+  if(instance) {
+    filter += ' AND metric.label.instance_name = "' + instance + '"';
+  }
+  console.log('filter:', filter, 'instance:', instance);
   monitoring.projects.timeSeries.list({
       auth: client.jwtClient,
       name: 'projects/' + client.projectId,
-      filter: 'metric.type = "' + metric + '"',
+      filter: filter,
       'interval.startTime': startDate.toJSON(),
       'interval.endTime': endDate.toJSON(),
       'aggregation.perSeriesAligner': Metrics.alignments[metric] || 'ALIGN_MAX',
@@ -515,7 +538,7 @@ function listDeployments(client, bot, message, filterStr) {
     });
 }
 
-function monitorMetrics(client, bot, message, metrics) {
+function monitorMetrics(client, bot, message, metrics, instance) {
   var responseData = {};
   var metricsComplete = 0;
   
@@ -535,7 +558,7 @@ function monitorMetrics(client, bot, message, metrics) {
   for (var i in metrics) {
     var metric = metrics[i];
     responseData[metric] = [];
-    monitorSeries(client, metric, monitorCallback);
+    monitorSeries(client, metric, instance, monitorCallback);
   }
 }
 

--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -13,6 +13,23 @@ function GCPClient(jwtClient) {
 }
 
 /**
+ * Authorize with Google Cloud platform using this object's jwtClient.
+ * @returns {Promise} - a promise that is fulfilled when authorization is complete
+ */
+GCPClient.prototype.authorize = function() {
+  var jwtClient = this.jwtClient;
+  return new Promise(function(fulfill, reject) {
+    jwtClient.authorize(function(err, tokens) {
+      if(err) {
+        console.log('error authorizing user: ', err); 
+        reject(err);
+      }
+      fulfill(tokens);
+    });
+  });
+};
+
+/**
  * Shows the detail for a specific deployment, including resources.
  * 
  * @param {object} userData - an object containing the projectId and region to use
@@ -22,14 +39,9 @@ function GCPClient(jwtClient) {
  */
 GCPClient.prototype.showDeployDetail = function(userData, bot, message, deployId) {
   var client = this;
-  this.jwtClient.authorize(function(err, tokens) {
-    if (err) {
-      console.log(err);
-      return;
-    }
-
+  this.authorize().then(function(tokens) {
     bot.reply(message, "Deployment detail for deployment " + deployId);
-    checkDeploy(userData, client, bot, message, deployId);
+    return checkDeploy(userData, client, bot, message, deployId);
   });
 };
 
@@ -42,14 +54,9 @@ GCPClient.prototype.showDeployDetail = function(userData, bot, message, deployId
  */
 GCPClient.prototype.showDeployList = function(userData, bot, message) {
   var client = this;
-  this.jwtClient.authorize(function(err, tokens) {
-    if (err) {
-      console.log(err);
-      return;
-    }
-
+  this.authorize().then(function(result) {
     bot.reply(message, "Deployment list: ");
-    listDeployments(userData, client, bot, message);
+    return listDeployments(userData, client, bot, message);
   });
 };
 
@@ -63,15 +70,10 @@ GCPClient.prototype.showDeployList = function(userData, bot, message) {
  */
 GCPClient.prototype.showDeploySummary = function(userData, bot, message, email) {
   var client = this;
-  this.jwtClient.authorize(function(err, tokens) {
-    if (err) {
-      console.log(err);
-      return;
-    }
-
+  this.authorize().then(function(tokens) {
     bot.reply(message, "Deployment summary for " + email);
     var filterStr = 'operation.user eq ' + email;
-    listDeployments(userData, client, bot, message, filterStr);
+    return listDeployments(userData, client, bot, message, filterStr);
   });
 };
 
@@ -91,51 +93,22 @@ GCPClient.prototype.newDeploy = function(userData, bot, message, repo, depFile) 
   var rawMaster = '/raw/master/';
   var baseURL = ghPref + repo + rawMaster;
 
-  fetchConfiguration(baseURL, yamlName, function(configString, imports, errors) {
-    if (errors) {
-      for(i = 0; i < errors.length; i++) {
-        bot.reply(message, '🚫 ' + errors[i]);
-      }
-    }
-    
+  return fetchConfiguration(baseURL, yamlName).then(function(result) {
+    var configString = result.body;
     if (!configString) {
-      if (!errors) {
-        bot.reply(message, "yaml file not found: " + url.resolve(baseURL, yamlName));
-      }
+      bot.reply(message, "yaml file not found: " + url.resolve(baseURL, yamlName));
       return;
     }
     
-    //now do the auth and call to manifest
-    client.jwtClient.authorize(function(err, tokens) {
-      if (err) {
-        console.log(err);
-        return;
+    var authorization = client.authorize();
+    authorization.then(insertDeployment(client, userData, bot, message, depFile, configString, result.imports));
+    authorization.catch(function(errors) {
+      for(i = 0; i < errors.length; i++) {
+        bot.reply(message, '🚫 ' + errors[i]);
       }
-
-      var depName = depFile + Math.floor(new Date() / 1000);
-      // Now insert the dependency
-      manager.deployments.insert({
-          auth: this.jwtClient,
-          project: userData.projectId,
-          resource: {
-            name: depName,
-            target: {
-              config: {
-                content: configString
-              },
-              imports: imports
-            }
-          }
-        },
-        function(err, resp) {
-          if(err) {
-            console.log(err);
-            return;
-          }
-          checkDeploy(userData, client, bot, message, depName);
-        });
-      });
     });
+    return authorization;
+  });
 };
 
 /**
@@ -154,18 +127,12 @@ GCPClient.prototype.listMetrics = function(userData, bot, message, metricFilters
     query = 'metric.type : "' + metricFilters.join('" AND metric.type : "') + '"';
   }
   
-  this.jwtClient.authorize(function(err, tokens) {
-    if (err) {
-      console.log(err);
-      return;
-    }
-    
+  this.authorize().then(function(tokens) {
     monitoring.projects.metricDescriptors.list({
       auth: client.jwtClient,
       name: 'projects/' + userData.projectId,
       filter: query },
       function(err, resp) {
-
         if(err) {
           console.log(err);
           return;
@@ -197,11 +164,7 @@ GCPClient.prototype.listMetrics = function(userData, bot, message, metricFilters
  */
 GCPClient.prototype.monitorMetricList = function(userData, bot, message, metrics, instance) {
   var client = this;
-  this.jwtClient.authorize(function(err, tokens) {
-    if (err) {
-      console.log(err);
-      return;
-    }
+  this.authorize().then(function(tokens) {
     monitorMetrics(userData, client, bot, message, metrics, instance);
   });
 };
@@ -235,13 +198,22 @@ function emojiForStatus(status) {
   }
 }
 
-function fetchConfiguration(baseURL, yamlName, callback) {
-  //get the file, use it as the resource info supplied to the insert cmd in gcp
-  var configString = "";
-  var files = [{ path: yamlName }];
-  
-  fetchNextFile(files, baseURL, true, function(body, imports, errors) {
-    callback(body, imports, errors);
+function fetchConfiguration(baseURL, yamlName) {
+  return new Promise(function(fulfill, reject) {
+    //get the file, use it as the resource info supplied to the insert cmd in gcp
+    var configString = "";
+    var files = [{ path: yamlName }];
+    
+    fetchNextFile(files, baseURL, true, function(body, imports, errors) {
+      if(errors && errors.length > 0) {
+        reject(errors);
+      } else {
+        fulfill({
+          body: body,
+          imports: imports
+        });
+      }
+    });
   });
 }
 
@@ -303,81 +275,91 @@ function sendDeployDetailReplies(bot, message, deploy, includeProgressLink) {
       var errors = deploy.operation.error.errors;
       for ( var errorNum in errors ) {
         var error = errors[errorNum];
-        console.log("error:", error);
         bot.reply(message, "🚫 *Error*: " + error.code + " *location*: " + error.location + " *message*: " + error.message);
       }
     }
   }
 }
 
+function listResources(userData, client, bot, message, depName) {
+  return new Promise(function (fulfill, reject) {
+    var params = {
+      auth: client.jwtClient,
+      project: userData.projectId,
+      deployment: depName
+    };
+    manager.resources.list(params, function(err, resp) {
+      if(err) {
+        console.log(err);
+        reject(err);
+        return;
+      }
+      if(!resp.resources) {
+        bot.reply(message, "No resourses.");
+        fulfill();
+        return;
+      }
+
+      //for each resource, check status of machine - if there's an error - check logs
+      resList = resp.resources;
+      bot.reply(message, "Deploy *" + depName + "* resource summary:");
+
+      for ( var i = 0; i < resList.length; i++ ) {
+        var resName = resList[i].name;
+        var resType = resList[i].type;
+
+        //get the yaml for the properties, and pull out some interesting info
+        var propObj = {};
+        if (resList[i].finalProperties) {
+          propObj = yaml.parse(resList[i].finalProperties);
+        }
+        bot.reply(message, "📋 Resource #" + i + ":");
+        bot.reply(message, "*Name:* " + resName +
+          "\n*Type:* " + resType +
+          "\n*Machine Class:* " + propObj.machineType +
+          "\n*Zone:* " + propObj.zone );
+      }
+      fulfill();
+    });
+  });
+}
+
 function checkDeploy(userData, client, bot, message, depName) {
   var status = "";
   var filterStr = 'name eq ' + depName;
 
-  return manager.deployments.list({
-    auth: client.jwtClient,
-    project: userData.projectId,
-    region: userData.region,
-    filter: filterStr },
-    function(err, resp) {
-      if( err) {
-        console.log(err);
+  return new Promise(function (fulfill, reject) {
+    var params = {
+      auth: client.jwtClient,
+      project: userData.projectId,
+      region: userData.region,
+      filter: filterStr 
+    };
+    manager.deployments.list(params, function(err, resp) {
+      if(err) {
+        reject(err);
         return;
       }
 
-      if( !resp.deployments ) {
+      if(!resp.deployments) {
         bot.reply(message, "No deployment found");
+        fulfill();
         return;
       }
       var currDeploy = resp.deployments[0];
       sendDeployDetailReplies(bot, message, resp.deployments[0]);
 
-      if( currDeploy.operation.status != "DONE" && currDeploy.operation.status != "COMPLETE" ) {
+      if(currDeploy.operation.status != "DONE" && currDeploy.operation.status != "COMPLETE") {
+        // Fulfill with another promise to check it again in 2 seconds.
         setTimeout(function() {
-          checkDeploy(userData, client, bot, message, depName);
+          fulfill(checkDeploy(userData, client, bot, message, depName));
         }, 2000);
-      }
-      else {
+      } else {
         //now get the resources based on the dep name
-        manager.resources.list({
-            auth: client.jwtClient,
-            project: userData.projectId,
-            deployment: depName
-          },
-          function(err, resp) {
-
-            if(err) {
-              console.log(err);
-              return;
-            }
-            if(!resp.resources) {
-              bot.reply(message, "No resourses.");
-              return;
-            }
-
-            //for each resource, check status of machine - if there's an error - check logs
-            resList = resp.resources;
-            bot.reply(message, "Deploy *" + depName + "* resource summary:");
-
-            for ( var i = 0; i < resList.length; i++ ) {
-              var resName = resList[i].name;
-              var resType = resList[i].type;
-
-              //get the yaml for the properties, and pull out some interesting info
-              var propObj = {};
-              if (resList[i].finalProperties) {
-                propObj = yaml.parse(resList[i].finalProperties);
-              }
-              bot.reply(message, "📋 Resource #" + i + ":");
-              bot.reply(message, "*Name:* " + resName +
-                "\n*Type:* " + resType +
-                "\n*Machine Class:* " + propObj.machineType +
-                "\n*Zone:* " + propObj.zone );
-            }
-          });
-        return;
+        fulfill(listResources(userData, client, bot, message, depName));
       }
     });
+  });
 }
 
 function invertMetricsData(responseData) {
@@ -506,42 +488,46 @@ function listDeployments(userData, client, bot, message, filterStr) {
   if (filterStr) {
     params.filter = filterStr;
   }
-  manager.deployments.list(params, function(err, resp) {
-      if( err) {
+  
+  return new Promise(function(fulfill, reject) {
+    manager.deployments.list(params, function(err, resp) {
+      if(err) {
         console.log(err);
         bot.reply(message, "🚫 There was an error listing deployments.");
+        reject(err);
         return;
       }
 
-      if( !resp.deployments ) {
+      if(!resp.deployments) {
         bot.reply(message, "No deployments to report on");
+        fulfill();
         return;
       }
 
       var deployTotalCount = resp.deployments.length;
-
       var activeDeploys = [];
       var deadDeploys = [];
 
-      for ( i = 0; i < resp.deployments.length; i++ ) {
-          if( resp.deployments[i].operation.status != 'DONE' ) {
-            activeDeploys.push( resp.deployments[i] );
-          }
-          else {
-            deadDeploys.push( resp.deployments[i] );
-          }
+      for (i = 0; i < resp.deployments.length; i++) {
+        if( resp.deployments[i].operation.status != 'DONE' ) {
+          activeDeploys.push( resp.deployments[i] );
+        } else {
+          deadDeploys.push( resp.deployments[i] );
+        }
       }
 
       bot.reply(message, "Deployments *Total Count*: " + deployTotalCount + " *Active*: " + activeDeploys.length);
 
-      for ( i = 0; i < activeDeploys.length; i++ ) {
+      for(i = 0; i < activeDeploys.length; i++) {
         sendDeployDetailReplies(bot, message, activeDeploys[i], true);
       }
 
-      for ( i = 0; i < deadDeploys.length; i++ ) {
+      for(i = 0; i < deadDeploys.length; i++) {
         sendDeployDetailReplies(bot, message, deadDeploys[i], false);
       }
+      fulfill();
     });
+  });
 }
 
 function monitorMetrics(userData, client, bot, message, metrics, instance) {
@@ -566,6 +552,33 @@ function monitorMetrics(userData, client, bot, message, metrics, instance) {
     responseData[metric] = [];
     monitorSeries(userData, client, metric, instance, monitorCallback);
   }
+}
+
+function insertDeployment(client, userData, bot, message, depFile, configString, imports) {
+  return new Promise(function(fulfill, reject) {
+    var depName = depFile + Math.floor(new Date() / 1000);
+    // Now insert the dependency
+    var params = {
+      auth: client.jwtClient,
+      project: userData.projectId,
+      resource: {
+        name: depName,
+        target: {
+          config: {
+            content: configString
+          },
+          imports: imports
+        }
+      }
+    };
+    manager.deployments.insert(params, function(err, resp) {
+      if(err) {
+        reject(err);
+      } else {
+        fulfill(checkDeploy(userData, client, bot, message, depName));
+      }
+    });
+  });
 }
 
 module.exports = GCPClient;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gcloud": "^0.28.0",
     "googleapis": "google/google-api-nodejs-client",
     "jsonfile": "^2.2.3",
+    "promise": "^7.1.1",
     "request": "^2.69.0",
     "yamljs": "^0.2.7"
   }


### PR DESCRIPTION
This PR contains a few changes towards the goals of integrating wit.ai and allowing the bot to be run by multiple users.

Changes:
1) A new `gcpbot setup <projectId> <region>` command. This saves the configuration per user instead of using environment variables to configure it. In the future this will be part of setting up the daily digest.
2) Stop passing the `bot` and `message` variables into every function call. Instead, use a simple `replier` function on the `GCPClient`
3) Switch to using promises for async calls, since this helped me chain them a bit better. This wasn't as big a win as I wanted, but I'm hoping it will pay off for future code.
