### PR TITLE
Multi team

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ If you have linked your local repo with the Beep Boop service (check [here](http
 
 The `deploy new` command relies on a publicly visible repo that has a valid yaml deployment file.  This is just a POC, and we'd probably want to use a remote template with command-line parameters supplied by the deployer.
 
+### Environment Variables
+
+GCPBot can be configured with a few different environment variables:
+
+	GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET - Your Google API credentials. Used to connect to Google APIs and get Oauth tokens for users. See (the Google API Manager)[https://console.developers.google.com/apis/credentials].
+
+	SLACK_TOKEN - provide this to connect to a single app. (Required if you are not connecting to BeepBoop)
+	BEEPBOOP_ID, BEEPBOOP_RESOURCER & BEEPBOOP_TOKEN - When these are provided they are used connect to the BeepBoop resourcer. See the [BeepBoop docs](https://beepboophq.com/docs/article/resourcer-api) for details.
+	
+	FIREBASE_URI, FIREBASE_SECRET - Specify a Firebase DB to save all user data. 
+
 ## Acknowledgements
 
 This code uses the [botkit](https://github.com/howdyai/botkit) npm module by the fine folks at Howdy.ai.

--- a/lib/authcache.js
+++ b/lib/authcache.js
@@ -34,18 +34,19 @@ AuthCache.prototype.lookupAuth = function(user) {
   });
 };
 
-AuthCache.prototype.createAuth = function(user) {
+AuthCache.prototype.createAuth = function(user, teamId) {
   var self = this;
   return this.lookupAuth(user).then(function(auth) {
+    auth.teamId = teamId;
     auth.client = new google.auth.OAuth2(self.defaults.googleClientId, self.defaults.googleClientSecret, self.defaults.oauthRedirectUrl);
     self.cache[user] = auth;
     return auth;
   });
 };
 
-AuthCache.prototype.generateAuthUrl = function(user) {
+AuthCache.prototype.generateAuthUrl = function(user, teamId) {
   var self = this;
-  return this.createAuth(user).then(function(auth) {
+  return this.createAuth(user, teamId).then(function(auth) {
     var scopes = [
       'https://www.googleapis.com/auth/ndev.cloudman',
       'https://www.googleapis.com/auth/cloud-platform',

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1,21 +1,42 @@
+var BeepBoop = require('beepboop-botkit');
 var CronJob = require('cron').CronJob;
 var GCPClient = require('./gcpclient');
 var Metrics = require('./metrics');
 var Scheduler = require('./scheduler');
 var yaml = require('yamljs');
 
-function Bot(controller, slackToken, botData, authCache) {
+var bots = {};
+function connect(controller, slackToken) {
+  if(slackToken) {
+    console.log('Connecting to single slack team');
+    var bot = controller.spawn({
+      token: slackToken
+    });
+    
+    bot.startRTM(function (err, bot, payload) {
+      if (err) {
+        throw new Error('Could not connect to Slack');
+      }
+      bots[bot.team_info.id] = bot;
+    });
+  } else {
+    var beepboop = BeepBoop.start(controller);
+    console.log('Connecting to BeepBoop resourcer');
+    beepboop.on('add_resource', function (msg) {
+      var resource = beepboop.workers[msg.resourceID];
+      if(resource) {
+        var teamId = resource.SlackTeamID;
+        bots[teamId] = resource.worker;
+      } else {
+        console.error('No bot found when added to team.');
+      }
+    });
+  }
+}
+
+function Bot(controller, botData, authCache, slackToken) {
   var scheduler = new Scheduler();
-  var bot = controller.spawn({
-    token: slackToken
-  });
-  
-  bot.startRTM(function (err, bot, payload) {
-    if (err) {
-      throw new Error('Could not connect to Slack');
-    }
-    botData.fetchBotIdentity(bot);
-  });
+  connect(controller, slackToken);
   
   function sayOrReply(bot, user, message, channel, parentMessage, private) {
     if(typeof message == "string") {
@@ -50,11 +71,11 @@ function Bot(controller, slackToken, botData, authCache) {
     };
   }
 
-  function showDigest(user, channel) {
+  function showDigest(user, teamId, channel) {
     var say = sayer(bot, user, channel);
     botData.getUserChannelData(user, channel).then(function(userData) {
       if(userData && userData.schedule) {
-        var gcpClient = new GCPClient(authCache, user, say);
+        var gcpClient = new GCPClient(authCache, teamId, user, say);
         var monitorUserData = { projectId: userData.schedule.projectId };
         return gcpClient.monitorMetricPack(monitorUserData, "simple");
       } else {
@@ -63,9 +84,9 @@ function Bot(controller, slackToken, botData, authCache) {
     }).catch(catchAll);
   }
 
-  function scheduleDigest(user, channel, projectId, schedule, tz) {
+  function scheduleDigest(user, teamId, channel, projectId, schedule, tz) {
     return scheduler.scheduleInterval(user + channel + projectId, schedule, tz, function() {
-      showDigest(user, channel);
+      showDigest(user, teamId, channel);
     });
   }
 
@@ -78,7 +99,7 @@ function Bot(controller, slackToken, botData, authCache) {
         var channelData = data.channels[channel];
         if(channelData && channelData.schedule) {
           console.log('scheduling user:', user, 'channel:', channel, 'project:', channelData.schedule.projectId, 'schedule:', channelData.schedule.schedule, 'timezone:', channelData.schedule.tz);
-          var result = scheduleDigest(user, channel, channelData.projectId, channelData.schedule.schedule, channelData.schedule.tz);
+          var result = scheduleDigest(user, channelData.teamId, channel, channelData.projectId, channelData.schedule.schedule, channelData.schedule.tz);
           if(!result) {
             console.error('scheduling failed');
           }
@@ -111,11 +132,12 @@ function Bot(controller, slackToken, botData, authCache) {
     botData.fetchUserInfo(message.user, bot).then(function(userInfo) {
       // First do the actual scheduling
       var tz = userInfo.user.tz;
-      var success = scheduleDigest(message.user, message.channel, projectId, scheduleString, tz);
+      var success = scheduleDigest(message.user, bot.team_info.id, message.channel, projectId, scheduleString, tz);
       
       if(success) {
         // Then save the data so it can be used later (especially on bot restart)
         var channelData = { schedule: {
+            teamId: bot.team_info.id,
             projectId: projectId,
             schedule: scheduleString,
             tz: tz
@@ -150,11 +172,11 @@ function Bot(controller, slackToken, botData, authCache) {
   });
 
   controller.hears(['gcpbot digest'], ['message_received','ambient'], function (bot, message) {
-    showDigest(message.user, message.channel).catch(catchAll);
+    showDigest(message.user, bot.team_info.id, message.channel).catch(catchAll);
   });
 
   controller.hears(['gcpbot d(eploy)? detail (.*)'], ['message_received','ambient'], function (bot, message) {
-    var gcpClient = new GCPClient(authCache, message.user, replier(bot, message));
+    var gcpClient = new GCPClient(authCache, message.user, bot.team_info.id, replier(bot, message));
     var depId = message.match[2].trim();
     botData.getUserChannelData(message.user, message.channel).then(function(userData) {
       if(!userData.projectId) { userDataErrorHandler(gcpClient.replier, userData); return; }
@@ -163,7 +185,7 @@ function Bot(controller, slackToken, botData, authCache) {
   });
 
   controller.hears(['gcpbot d(eploy)? summary (.*)'], ['message_received','ambient'], function (bot, message) {
-    var gcpClient = new GCPClient(authCache, message.user, replier(bot, message));
+    var gcpClient = new GCPClient(authCache, message.user, bot.team_info.id, replier(bot, message));
     var user = message.match[2].trim();
     var email = user.substring( user.indexOf(':') + 1, user.indexOf('|'));
     console.log(email);
@@ -175,7 +197,7 @@ function Bot(controller, slackToken, botData, authCache) {
   });
 
   controller.hears(['gcpbot deploy list'], ['message_received','ambient'], function (bot, message) {
-    var gcpClient = new GCPClient(authCache, message.user, replier(bot, message));
+    var gcpClient = new GCPClient(authCache, message.user, bot.team_info.id, replier(bot, message));
     botData.getUserChannelData(message.user, message.channel).then(function(userData) {
       if(!userData.projectId) { userDataErrorHandler(gcpClient.replier, userData); return; }
       return gcpClient.showDeployList(userData);
@@ -184,7 +206,7 @@ function Bot(controller, slackToken, botData, authCache) {
 
   // DEPLOYMENT of a file from github
   controller.hears(['gcpbot d(eploy)? new (.*) (.*)'], ['message_received','ambient'], function (bot, message) {
-    var gcpClient = new GCPClient(authCache, message.user, replier(bot, message));
+    var gcpClient = new GCPClient(authCache, message.user, bot.team_info.id, replier(bot, message));
     var repo = message.match[2].trim();
     var depFile = message.match[3].trim();
     
@@ -213,7 +235,7 @@ function Bot(controller, slackToken, botData, authCache) {
   });
 
   controller.hears(['gcpbot m(onitor)? m(etrics)?(.*)?'], ['message_received','ambient'], function (bot, message) {
-    var gcpClient = new GCPClient(authCache, message.user, replier(bot, message));
+    var gcpClient = new GCPClient(authCache, message.user, bot.team_info.id, replier(bot, message));
     var metricString = message.match[3];
     var parsedMetrics = parseMetricsFromMessage(metricString);
     
@@ -228,7 +250,7 @@ function Bot(controller, slackToken, botData, authCache) {
     
     // First see if there's a named package
     if(Metrics.packages[metricString]) {
-      var gcpClient = new GCPClient(authCache, message.user, replier(bot, message));
+      var gcpClient = new GCPClient(authCache, message.user, bot.team_info.id, replier(bot, message));
       botData.getUserChannelData(message.user, message.channel).then(function(userData) {
         if(!userData.projectId) { userDataErrorHandler(gcpClient.replier, userData); return; }
         return gcpClient.monitorMetricPack(userData, metricString);
@@ -243,7 +265,7 @@ function Bot(controller, slackToken, botData, authCache) {
     var metricString = message.match[2];
     var metrics = parseMetricsFromMessage(metricString);
     if (metrics) {
-      var gcpClient = new GCPClient(authCache, message.user, replier(bot, message));
+      var gcpClient = new GCPClient(authCache, message.user, bot.team_info.id, replier(bot, message));
       botData.getUserChannelData(message.user, message.channel).then(function(userData) {
         if(!userData.projectId) { userDataErrorHandler(gcpClient.replier, userData); return; }
         return gcpClient.monitorMetricList(userData, metrics);
@@ -277,7 +299,7 @@ function Bot(controller, slackToken, botData, authCache) {
     console.error(err); 
   }
   
-  return bot;
+  return bots;
 }
 
 module.exports = Bot;

--- a/lib/botdata.js
+++ b/lib/botdata.js
@@ -123,18 +123,6 @@ BotData.prototype.getAllUserData = function() {
 };
 
 /**
- * Fetch the identity information for a specific bot. Stashes the icon url
- * in `bot.identity.icon`.
- * 
- * @param {*} bot - the bot to fetch the identity for
- */
-BotData.prototype.fetchBotIdentity = function(bot) {
-  bot.api.users.info({ user: bot.identity.id }, function(err, result) {
-    bot.identity.icon = result.user.profile.image_original;
-  });
-};
-
-/**
  * Fetch the identity information for a specific user.
  * 
  * @param {*} bot - the bot to fetch the identity for

--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -8,8 +8,9 @@ var Metrics = require('./metrics');
 var GoogleChart = require('./googlechart');
 var Utils = require('./utils');
 
-function GCPClient(authCache, user, replier) {
+function GCPClient(authCache, user, teamId, replier) {
   this.user = user;
+  this.teamId = teamId;
   this.authCache = authCache;
   this.replier = replier;
 }
@@ -39,9 +40,9 @@ GCPClient.prototype.authorize = function() {
       return auth;
     }
     if(!auth.client) {
-      self.authCache.createAuth(self.user).then(function(auth) {
+      self.authCache.createAuth(self.user, self.teamId).then(function(auth) {
         self.auth = auth;
-        return self.authCache.generateAuthUrl(self.user).then(function(url) {
+        return self.authCache.generateAuthUrl(self.user, self.teamId).then(function(url) {
           replier("🔑 Log into your Google Cloud Platform account here to give me authorization: " + url, true);
         });
       });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/beepboophq/node-slack-bot#readme",
   "dependencies": {
+    "beepboop-botkit": "^1.3.0",
     "botkit": "0.0.5",
     "botkit-storage-firebase": "https://github.com/echicken/botkit-storage-firebase/tarball/72a538548ac3e2157ecaacb1b4865646e5ebb241",
     "cron": "^1.1.0",


### PR DESCRIPTION
Add support for multi-team bots in BeepBoop using [beepboop-botkit](https://github.com/BeepBoopHQ/beepboop-botkit). The main changes are tracking which teams are connected and looking those up in the places I had assumed there was only one bot (mostly in the OAuth server part).

I also made it so that if a Slack token is provided but no beep boop environment variables then it will fall back to a single team bot.

See [BeepBoop docs](https://beepboophq.com/docs/article/resourcer-api)
