### PR TITLE
Better digests

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -82,10 +82,11 @@ Bot.prototype.setupActions = function(controller) {
   var mentionsAndDMs = ['direct_message', 'mention', 'direct_mention'];
   var gcpBot = this;
   controller.hears('help', mentionsAndDMs, function(bot, message) {
-    var packs = '`' + Object.keys(Metrics.packages).join('`, `') + '`';
+    var packs = '`' + Metrics.getPackageList().join('`, `') + '`';
     var botName = message.event != 'direct_message' ? '@' + bot.identity.name + ' ' : '';
     var help = 'I will respond to the following messages: \n' +
         '`' + botName + 'schedule <projectId> <schedule>` to schedule a digest. Schedule is specified with cron syntax. Leave blank to schedule for 9am every morning.\n' +
+        '`' + botName + 'schedule` to start scheduling a digest.\n' +
         '`' + botName + 'unschedule` to cancel a scheduled digest in this channel.\n' +
         '`' + botName + 'digest` to show the currently scheduled digest now.\n' +
         '`' + botName + 'project <projectId>` to select a project to use for the other commands in this channel. This is a per user setting. You can change it at any time.\n' +
@@ -118,6 +119,38 @@ Bot.prototype.setupActions = function(controller) {
 
   controller.hears(['unschedule'], mentionsAndDMs, function(bot, message) {
     gcpBot.unschedule(bot, message);
+  });
+
+  controller.hears(['schedule'], mentionsAndDMs, function(bot, message) {
+    var projectId = null;
+    var scheduleString = null;
+    var metricPack = null;
+    var checkDone = function(convo) {
+      if(projectId && scheduleString && metricPack) {
+        gcpBot.schedule(bot, message, projectId, scheduleString, metricPack);
+        convo.stop();
+      }
+    };
+    
+    // start a conversation to setup a schedule, ask questions in order
+    bot.startConversation(message, function(err, convo) {
+      convo.ask('Which project would you like to schedule a digest for?', function(response, convo) {
+        projectId = response.text;
+        checkDone(convo);
+        convo.next();
+      });
+      convo.ask('What cron schedule should the digest run on?', function(response, convo) {
+        scheduleString = response.text;
+        checkDone(convo);
+        convo.next();
+      });
+      var metricPackages = '`' + Metrics.getPackageList().join('`, `') + '`';
+      convo.ask('Which metric pack would you like to use? One of: ' + metricPackages, function(response, convo) {
+        metricPack = response.text;
+        checkDone(convo);
+        convo.next();
+      });
+    });
   });
 
   controller.hears(['digest'], mentionsAndDMs, function(bot, message) {
@@ -174,24 +207,27 @@ Bot.prototype.setProject = function(bot, message, projectId) {
   bot.reply(message, 'Ok, using project `' + projectId + '` in this channel');
 };
 
-Bot.prototype.schedule = function(bot, message, projectId, scheduleString) {
+Bot.prototype.schedule = function(bot, message, projectId, scheduleString, metricPack) {
+  metricPack = metricPack || 'simple';
   var self = this;
   // Fetch the user data so we know the time zone
   self.botData.fetchUserInfo(message.user, bot).then(function(userInfo) {
     // First do the actual scheduling
     var tz = userInfo.user.tz;
-    var success = self.scheduleDigest(message.user, bot.team_info.id, message.channel, projectId, scheduleString, tz);
+    var scheduleData = {
+        teamId: bot.team_info.id,
+        projectId: projectId,
+        schedule: scheduleString,
+        metricPack: metricPack,
+        tz: tz
+    };
+    var success = self.scheduleDigest(message.user, message.channel, scheduleData);
     
     if(success) {
       // Then save the data so it can be used later (especially on bot restart)
-      var channelData = { schedule: {
-          teamId: bot.team_info.id,
-          projectId: projectId,
-          schedule: scheduleString,
-          tz: tz
-      } };
+      var channelData = { schedule: scheduleData };
       self.botData.saveUserChannelData(message.user, message.channel, channelData);
-      bot.reply(message, 'Ok, I scheduled a digest for `' + scheduleString + '` in this channel');
+      bot.reply(message, 'Ok, I scheduled a `' + projectId + '` digest at `' + scheduleString + '` in this channel. Showing `' + metricPack + '` metrics.');
     } else {
       // Or tell the user that the scheduling failed
       bot.reply(message, 'I could not schedule a digest for `' + scheduleString + '`. Is something wrong with your cron string?');
@@ -301,7 +337,8 @@ Bot.prototype.showScheduledDigest = function (user, teamId, channel) {
     if(userData && userData.schedule) {
       var gcpClient = new GCPClient(self.authCache, user, teamId, say);
       var monitorUserData = { projectId: userData.schedule.projectId };
-      return gcpClient.monitorMetricPack(monitorUserData, "simple");
+      var metricPack = userData.schedule.metricPack || 'simple';
+      return gcpClient.monitorMetricPack(monitorUserData, metricPack);
     } else {
       say("You do not have a scheduled digest in this channel.");
       console.error("Trying to run digest with no data. User:", user, "Channel:", channel);
@@ -309,10 +346,10 @@ Bot.prototype.showScheduledDigest = function (user, teamId, channel) {
   }).catch(catchAll);
 };
 
-Bot.prototype.scheduleDigest = function(user, teamId, channel, projectId, schedule, tz) {
+Bot.prototype.scheduleDigest = function(user, channel, scheduleData) {
   var self = this;
-  return self.scheduler.scheduleInterval(user + channel + projectId, schedule, tz, function() {
-    self.showScheduledDigest(user, teamId, channel);
+  return self.scheduler.scheduleInterval(user + channel + scheduleData.projectId, scheduleData.schedule, scheduleData.tz, function() {
+    self.showScheduledDigest(user, scheduleData.teamId, channel);
   });
 };
 
@@ -355,8 +392,8 @@ Bot.prototype.scheduleExistingDigests = function() {
       for(var channel in data.channels) {
         var channelData = data.channels[channel];
         if(channelData && channelData.schedule) {
-          console.log('scheduling user:', user, 'team:', channelData.schedule.teamId, 'channel:', channel, 'project:', channelData.schedule.projectId, 'schedule:', channelData.schedule.schedule, 'timezone:', channelData.schedule.tz);
-          var result = self.scheduleDigest(user, channelData.schedule.teamId, channel, channelData.projectId, channelData.schedule.schedule, channelData.schedule.tz);
+          console.log('scheduling user:', user, 'team:', channelData.schedule.teamId, 'channel:', channel, 'project:', channelData.schedule.projectId, 'schedule:', channelData.schedule.schedule, 'metricPack:', channelData.schedule.metricPack, 'timezone:', channelData.schedule.tz);
+          var result = self.scheduleDigest(user, channel, channelData.schedule);
           if(!result) {
             console.error('scheduling failed');
           }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -90,6 +90,7 @@ Bot.prototype.setupActions = function(controller) {
         '`' + botName + 'unschedule` to cancel a scheduled digest in this channel.\n' +
         '`' + botName + 'digest` to show the currently scheduled digest now.\n' +
         '`' + botName + 'project <projectId>` to select a project to use for the other commands in this channel. This is a per user setting. You can change it at any time.\n' +
+        '`' + botName + 'projects` to list all your projects.\n' +
         '`' + botName + 'deploy list` for a list of all deployment manager jobs and their status.\n' +
         '`' + botName + 'deploy summary <email>` for a list of all deployment manager jobs initiated by the provided user and their status.\n' +
         '`' + botName + 'deploy new <repo> <depfile>` to create a new deployment using a yaml file in the github repo identified with a yaml file called <depfile>.yaml.\n' +
@@ -103,6 +104,10 @@ Bot.prototype.setupActions = function(controller) {
   
   controller.on('bot_channel_join', function(bot, message) {
     bot.reply(message, "I'm here! Type `gpcbot help` to see what I can do.");
+  });
+  
+  controller.hears(['projects', 'project list'], mentionsAndDMs, function(bot, message) {
+    gcpBot.listProjects(bot, message);
   });
 
   controller.hears(['project (.*)'], mentionsAndDMs, function(bot, message) {
@@ -205,6 +210,13 @@ Bot.prototype.setProject = function(bot, message, projectId) {
   };
   this.botData.saveUserChannelData(message.user, message.channel, data);
   bot.reply(message, 'Ok, using project `' + projectId + '` in this channel');
+};
+
+Bot.prototype.listProjects = function(bot, message) {
+  var gcpClient = new GCPClient(this.authCache, message.user, bot.team_info.id, replier(bot, message));
+  this.botData.getUserChannelData(message.user, message.channel).then(function(userData) {
+    return gcpClient.listProjects(userData);
+  }).catch(catchAll);
 };
 
 Bot.prototype.schedule = function(bot, message, projectId, scheduleString, metricPack) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -90,7 +90,7 @@ Bot.prototype.setupActions = function(controller) {
         '`' + botName + 'unschedule` to cancel a scheduled digest in this channel.\n' +
         '`' + botName + 'digest` to show the currently scheduled digest now.\n' +
         '`' + botName + 'project <projectId>` to select a project to use for the other commands in this channel. This is a per user setting. You can change it at any time.\n' +
-        '`' + botName + 'projects` to list all your projects.\n' +
+        '`' + botName + 'projects` to list all your projects. Also prompts you to select the project after listing (see project <projectId>)\n' +
         '`' + botName + 'deploy list` for a list of all deployment manager jobs and their status.\n' +
         '`' + botName + 'deploy summary <email>` for a list of all deployment manager jobs initiated by the provided user and their status.\n' +
         '`' + botName + 'deploy new <repo> <depfile>` to create a new deployment using a yaml file in the github repo identified with a yaml file called <depfile>.yaml.\n' +
@@ -212,10 +212,55 @@ Bot.prototype.setProject = function(bot, message, projectId) {
   bot.reply(message, 'Ok, using project `' + projectId + '` in this channel');
 };
 
+function getResponseText(bot, response) {
+  var responseText = response.text;
+  // Remove any @mention of this bot
+  responseText = responseText.replace(new RegExp('<@' + bot.identity.id + '>(:)?'), '');
+  return responseText.trim();
+}
+
+Bot.prototype.startProjectChoiceConversation = function(bot, message, projects, shouldRepeat, question) {
+  var self = this;
+  bot.startConversation(message, function(err, convo) {
+    var repeated = false;
+    convo.ask(question, function(response, convo) {
+      var responseText = getResponseText(bot, response);
+      var found = projects.find(function(project) {
+        return project.name == responseText || project.projectId == responseText;
+      });
+      if(found && found.projectId) {
+        self.setProject(bot, message, found.projectId);
+      } else if(shouldRepeat) {
+        if(!repeated) {
+          repeated = true;
+          convo.repeat();
+        } else {
+          convo.say("I don't understand you. Use `project <projectId>` to set your project.");
+        }
+      }
+      convo.next();
+    });
+  });
+};
+
 Bot.prototype.listProjects = function(bot, message) {
+  var self = this;
   var gcpClient = new GCPClient(this.authCache, message.user, bot.team_info.id, replier(bot, message));
   this.botData.getUserChannelData(message.user, message.channel).then(function(userData) {
-    return gcpClient.listProjects(userData);
+    return gcpClient.listProjects(userData).then(function(projects) {
+      // If there's only one project, set it as the project for this channel.
+      if(projects && projects.length == 1 && !userData.projectId) {
+        self.setProject(bot, message, projects[0].projectId);
+      // If there is no project setup and more than one project, ask the user to pick
+      } else {
+        if(!userData.projectId) {
+          self.startProjectChoiceConversation(bot, message, projects, true, 'You have not set a project to use in this channel. Which would you like to use?');
+        // If there's a project set up give the user a chance to change it
+        } else {
+          self.startProjectChoiceConversation(bot, message, projects, false, 'You are using `' + userData.projectId + '` in this channel. To change projects, reply with a project name or id.');
+        }
+      }
+    });
   }).catch(catchAll);
 };
 

--- a/lib/botdata.js
+++ b/lib/botdata.js
@@ -31,7 +31,7 @@ BotData.prototype.getUserChannelData = function(user, channel) {
   var self = this;
   return this.getUserData(user).then(function(userData) {
     if(!userData || !userData.channels || !userData.channels[channel]) {
-      return Promise.resolve();
+      return Promise.resolve({});
     } else {
       return userData.channels[channel];
     }

--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -214,27 +214,31 @@ GCPClient.prototype.monitorMetricPack = function(userData, packName, instance) {
  */
 GCPClient.prototype.listProjects = function(userData) {
   var client = this;
-  this.authorize().then(function(auth) {
+  return this.authorize().then(function(auth) {
     if(!auth) { return Promise.resolve(); }
-    return cloudresourcemanager.projects.list({
-      auth: client.auth.client },
-      function(err, resp) {
-        client.updateAuth();
-        if(err) {
-          console.log('cloudresourcemanager.projects.list', err);
-          return Promise.reject(err);
+    return new Promise(function(fulfill, reject) {
+      cloudresourcemanager.projects.list({
+        auth: client.auth.client },
+        function(err, resp) {
+          client.updateAuth();
+          if(err) {
+            console.log('cloudresourcemanager.projects.list', err);
+            reject(err);
+            return;
+          }
+          
+          var projects = resp.projects;
+          console.log('projects:', projects.length);
+          var projectText = projects.length == 1 ? ' project:' : ' projects:';
+          var responseMessage = 'You have ' +  projects.length + projectText;
+          for(i = 0; i < projects.length; i++) {
+            responseMessage += '\n🏷 *' + projects[i].name + '* | ' + projects[i].projectId;
+          }
+          client.replier(responseMessage);
+          fulfill(projects);
         }
-        
-        var projects = resp.projects;
-        console.log('projects:', projects.length);
-        var projectText = projects.length == 1 ? ' project:' : ' projects:';
-        var responseMessage = 'You have ' +  projects.length + projectText;
-        for(i = 0; i < projects.length; i++) {
-          responseMessage += '\n🏷 *' + projects[i].name + '* | projectId: ' + projects[i].projectId;
-        }
-        client.replier(responseMessage);
-      }
-    );
+      );
+    });
   });
 };
 

--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -2,6 +2,7 @@ var request = require('request');
 var google = require('googleapis');
 var manager = google.deploymentmanager('v2');
 var monitoring = google.monitoring('v3');
+var cloudresourcemanager = google.cloudresourcemanager('v1');
 var yaml = require('yamljs');
 var url = require('url');
 var Metrics = require('./metrics');
@@ -55,7 +56,7 @@ GCPClient.prototype.authorize = function() {
 /**
  * Shows the detail for a specific deployment, including resources.
  * 
- * @param {object} userData - an object containing the projectId and region to use
+ * @param {object} userData - an object containing the projectId
  * @param {string} deployId - the id of the deployment to show detail for
  */
 GCPClient.prototype.showDeployDetail = function(userData, deployId) {
@@ -70,7 +71,7 @@ GCPClient.prototype.showDeployDetail = function(userData, deployId) {
 /**
  * Shows a list of all deployments in the project
  * 
- * @param {object} userData - an object containing the projectId and region to use
+ * @param {object} userData - an object containing the projectId
  */
 GCPClient.prototype.showDeployList = function(userData) {
   var client = this;
@@ -86,7 +87,7 @@ GCPClient.prototype.showDeployList = function(userData) {
 /**
  * Shows a summary of the deploys associated with a certain email address
  * 
- * @param {object} userData - an object containing the projectId and region to use
+ * @param {object} userData - an object containing the projectId
  * @param {string} email - the email address to search by
  */
 GCPClient.prototype.showDeploySummary = function(userData, email) {
@@ -104,7 +105,7 @@ GCPClient.prototype.showDeploySummary = function(userData, email) {
 /**
  * Creates a new deploy from a specified yaml file in a github repo.
  * 
- * @param {object} userData - an object containing the projectId and region to use
+ * @param {object} userData - an object containing the projectId
  * @param {string} repo - the github repo to look in
  * @param {string} depFile - the name of the config file (without extension)
  */
@@ -139,7 +140,7 @@ GCPClient.prototype.newDeploy = function(userData, repo, depFile) {
  * Show a list of metrics with an optional array of filter strings. The filter works by matching
  * any metric that contains ALL the provided strings. Metrics will be truncated at 50.
  * 
- * @param {object} userData - an object containing the projectId and region to use
+ * @param {object} userData - an object containing the projectId
  * @param {string[]} metricFilters - an array of Strings that filters the metrics to only ones that contain ALL of the Strings
  */
 GCPClient.prototype.listMetrics = function(userData, metricFilters) {
@@ -179,7 +180,7 @@ GCPClient.prototype.listMetrics = function(userData, metricFilters) {
 /**
  * Reply with the results of monitoring a list of metrics.
  * 
- * @param {object} userData - an object containing the projectId and region to use
+ * @param {object} userData - an object containing the projectId
  * @param {string[]} metrics - a list of GCP metrics that should be monitored. e.g. "compute.googleapis.com/instance/cpu/utilization"
  * @param {string} instance - the instance to filter to
  */
@@ -194,7 +195,7 @@ GCPClient.prototype.monitorMetricList = function(userData, metrics, instance) {
 /**
  * Reply with the results of monitoring a list of metrics from a predefined pack.
  * 
- * @param {object} userData - an object containing the projectId and region to use
+ * @param {object} userData - an object containing the projectId
  * @param {string} packName - the name of a predefined list of metrics e.g. "cpu", "simple"
  */
 GCPClient.prototype.monitorMetricPack = function(userData, packName, instance) {
@@ -204,6 +205,37 @@ GCPClient.prototype.monitorMetricPack = function(userData, packName, instance) {
   } else {
     return new Promise.resolve([]);
   }
+};
+
+/**
+ * Show a list of projects for a user 
+ * 
+ * @param {object} userData - an object containing the projectId
+ */
+GCPClient.prototype.listProjects = function(userData) {
+  var client = this;
+  this.authorize().then(function(auth) {
+    if(!auth) { return Promise.resolve(); }
+    return cloudresourcemanager.projects.list({
+      auth: client.auth.client },
+      function(err, resp) {
+        client.updateAuth();
+        if(err) {
+          console.log('cloudresourcemanager.projects.list', err);
+          return Promise.reject(err);
+        }
+        
+        var projects = resp.projects;
+        console.log('projects:', projects.length);
+        var projectText = projects.length == 1 ? ' project:' : ' projects:';
+        var responseMessage = 'You have ' +  projects.length + projectText;
+        for(i = 0; i < projects.length; i++) {
+          responseMessage += '\n🏷 *' + projects[i].name + '* | projectId: ' + projects[i].projectId;
+        }
+        client.replier(responseMessage);
+      }
+    );
+  });
 };
 
 function emojiForStatus(status) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,4 +1,8 @@
 module.exports = {
+    getPackageList: function() {
+        return Object.keys(this.packages);
+    },
+    
     packages: {
         'compute': { metrics: [
             'compute.googleapis.com/firewall/dropped_bytes_count',


### PR DESCRIPTION
These changes are focused on the usability of scheduling a digest.

The first change was enabling conversational setup of a schedule, which also includes choosing which metric pack to use. 
![screen shot 2016-05-13 at 12 03 32 pm](https://cloud.githubusercontent.com/assets/90887/15255621/c5266c2c-1902-11e6-8ff6-cb1a96cba2a7.png)

I also added the ability to list projects with the `projects` command, which makes it easier to set the project to be used. After listing your projects, it lets you set which project to use for this channel, which is much nicer than the existing command. This feature also adapts to the situation: it automatically sets the project if you have only one and reacts a bit differently if you have no project set vs already having one. (I have more work to do on this, but this was a good stopping point.)
![screen shot 2016-05-13 at 12 08 56 pm](https://cloud.githubusercontent.com/assets/90887/15261638/587cadf4-1923-11e6-98e2-b55af18e420a.png)

I also fixed a bug that caused an error if you didn't set a project before doing a request that required it.
