### PR TITLE
Keep the refresh token when updating auth tokens

### DIFF
--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -25,7 +25,9 @@ GCPClient.prototype.updateAuth = function() {
   var auth = this.auth;
   // If the access token has changed, update the credentials. (This happens automatically after requests)
   if(auth.tokens.access_token != auth.client.credentials.access_token) {
-    auth.tokens = auth.client.credentials;
+    // Only update the access token and expiry date so we keep the refresh token
+    auth.tokens.access_token = auth.client.credentials.access_token;
+    auth.tokens.expiry_date = auth.client.credentials.expiry_date;
     this.authCache.saveAuth(auth);
   }
 };
@@ -234,6 +236,7 @@ GCPClient.prototype.runScript = function(script, args) {
       if(err) {
         reject(err);
       } else {
+        client.updateAuth();
         fulfill(results);
       }
     };


### PR DESCRIPTION
When adding slambdas, I noticed that authentication was failing periodically and needed new tokens to make it work. I suspected it was the tokens expiring and not refreshing automatically, which turned out to be true. The root cause was me overwriting the refresh token, so refreshing the access token failed. This PR just fixes that so the refresh token is preserved after getting a new access token.
