### PR TITLE
Slambads in context

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -191,12 +191,16 @@ Bot.prototype.setupActions = function(controller) {
     var argumentsString = Utils.cleanupQuotes(message.match[2].trim());
     
     // Parse the arguments out of the arg string, allowing quoted args to have spaces
-    var regex = /\w+|"[\w\s]+"/g;
+    var regex = /\w+|[<"][^"]+[">]/g;
     var args = argumentsString.match(regex) || [];
     args = args.map(function(arg) {
       if(arg.startsWith('"') && arg.endsWith('"')) {
         arg = arg.substring(1, arg.length - 1);
-      } 
+      }
+      if(arg.startsWith("<") && arg.endsWith(">")) {
+        var pipeIndex = arg.indexOf("|");
+        arg = arg.substring(pipeIndex + 1, arg.length - 1);
+      }
       return arg;
     });
     

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -624,7 +624,7 @@ function formatObject(obj) {
 }
 
 Bot.prototype.addScript = function(bot, message, script, name) {
-  var runner = new ScriptRunner(script, {}, [function(err, result) {
+  var runner = new ScriptRunner('module.exports = ' + script, {}, [function(err, result) {
     if(err) {
       bot.reply(message, "Error adding script: " + err);
     } else {
@@ -718,7 +718,7 @@ Bot.prototype.runScript = function(bot, message, scriptName, args) {
       argStrings = argStrings.concat(extraArgs);
       bot.reply(message, "Running script `" + scriptName + "(" + argStrings.join(', ') + ")`");
 
-      return gcpClient.runScript(scriptData.script, allArgs).then(function(result) {
+      return gcpClient.runScript(scriptData.script, allArgs, scripts).then(function(result) {
         bot.reply(message, formatScriptResult(result));
       }, function(err) {
         bot.reply(message, "Something went wrong. :/ `" + err.message + "`");

--- a/lib/gcpclient.js
+++ b/lib/gcpclient.js
@@ -224,7 +224,7 @@ GCPClient.prototype.getProjects = function() {
   });
 };
 
-GCPClient.prototype.runScript = function(script, args) {
+GCPClient.prototype.runScript = function(script, args, teamScripts) {
   args = args || [];
   var client = this;
   return new Promise(function(fulfill, reject) {
@@ -241,8 +241,16 @@ GCPClient.prototype.runScript = function(script, args) {
       }
     };
     
+    // Make other scripts available to the original script
+    var scripts = "var scripts = {\n";
+    for(var key in teamScripts) {
+      scripts += key + ": " + teamScripts[key].script + ",\n";
+    }
+    scripts += "}\n";
+    var fullScript = scripts + " module.exports = " + script;
+    
     // Compile
-    var runner = new ScriptRunner(script, {}, callback);
+    var runner = new ScriptRunner(fullScript, {console: console}, callback);
     var compiled = runner.compile();
     if(!compiled) {
       reject(new Error('Script did not complile'));


### PR DESCRIPTION
This change makes calling other scripts possible from within a script. This is done by calling `scripts.myFunc(param1, param2, gcloud, callback)`

NOTE: I also removed the requirement that scripts be prefixed by `module.exports =` and do it for the user automatically.

Here is an example of two scripts, where the second script calls the first:

```
function findEntity(entityName, field, value, gcloud, cb) {
  var datastore = gcloud.datastore()
  var query = datastore.createQuery('staging', entityName)
  query.filter(field, value)
  datastore.runQuery(query, function (err, entities) {
    if (err) {
      return cb(err)
    }
    cb(null, entities.map(function(o) { return o.data }))
  })
}
```

```
function findUserByEmail(email, gcloud, cb) {
  scripts.findEntity('User', 'Email', email, gcloud, cb);
}
```
