### PR TITLE
testing botkit fork for handling rtm close errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/beepboophq/node-slack-bot#readme",
   "dependencies": {
-    "beepboop-botkit": "^1.3.0",
-    "botkit": "0.0.14",
+    "beepboop-botkit": "^1.4.0",
+    "botkit": "selfcontained/botkit#f62821f2cbb9b1a92e8b81fa7c94a4d932d0b73e",
     "botkit-storage-firebase": "https://github.com/echicken/botkit-storage-firebase/tarball/72a538548ac3e2157ecaacb1b4865646e5ebb241",
     "cron": "^1.1.0",
     "csrf": "^3.0.1",


### PR DESCRIPTION
Switches to a forked version of botkit to try and resolve some issues around the rtm connection closing and not reconnecting.  Currently logs some close event info and unconditionally reconnects.  After gathering some logs would like to make the reconnect attempt conditional upon actual socket close errors instead of cases where the rtm is closed on purpose for some reason.
